### PR TITLE
Adjust translation-unit-docs for openconfig changes

### DIFF
--- a/Configuration datasets/interfaces/ethernet_interface.md
+++ b/Configuration datasets/interfaces/ethernet_interface.md
@@ -54,24 +54,24 @@ openconfig-interfaces:interfaces/interface/<intf-id>
                     }
                 ]
             }
+            "damping:damping": {
+                "config": {
+                    "enabled": <true/false>,
+                    "half-life": <half-life>,
+                    "reuse": <reuse>,
+                    "suppress": <suppres>,
+                    "max-supress": <max-supress>
+                }
+            }
+            "cisco-if-extension:statistics": {
+                "config": {
+                    "load-interval": <load_interval>
+                }
+            }
             "openconfig-if-ethernet:ethernet": {
                 "config": {
                     "openconfig-if-aggregate:aggregate-id": <bundle-id>
-                }
-                "damping:damping": {
-                    "config": {
-                        "enabled": <true/false>,
-                        "half-life": <half-life>,
-                        "reuse": <reuse>,
-                        "suppress": <suppres>,
-                        "max-supress": <max-supress>
-                    }
-                }
-                "cisco-if-extension:statistics": {
-                    "config": {
-                        "load-interval": <load_interval>
-                    }
-                }
+		}
             }
         }
     ]

--- a/Configuration datasets/interfaces/lag_interface.md
+++ b/Configuration datasets/interfaces/lag_interface.md
@@ -45,22 +45,22 @@ openconfig-interfaces:interfaces/interface/<intf-id>
                     }
                 ]
             }
+            "damping:damping": {
+                "config": {
+                    "enabled": <true/false>,
+                    "half-life": <half-life>,
+                    "reuse": <reuse>,
+                    "suppress": <suppres>,
+                    "max-supress": <max-supress>
+                }
+            }
+            "cisco-if-extension:statistics": {
+                "load-interval": <load-interval>
+            }
             "openconfig-if-aggregate:aggregation": {
                 "config": {
                     "min-links": <min-links>
                     "juniper-if-aggregate-extension:link-speed": <link_speed>
-                }
-                "damping:damping": {
-                    "config": {
-                        "enabled": <true/false>,
-                        "half-life": <half-life>,
-                        "reuse": <reuse>,
-                        "suppress": <suppres>,
-                        "max-supress": <max-supress>
-                    }
-                }
-                "cisco-if-extension:statistics": {
-                    "load-interval": <load-interval>
                 }
                 "bfd:bfd": {
                     "config": {


### PR DESCRIPTION
Openconfig interface models changed a little bit in
https://github.com/FRINXio/openconfig/commit/c80b9831f15e87afdac6681d540d3743a2ab3294.

Adjust our configuration datasets for that.

Signed-off-by: Jakub Morvay <jmorvay@frinx.io>