### PR TITLE
Update Probes configurations

### DIFF
--- a/Configuration datasets/README.md
+++ b/Configuration datasets/README.md
@@ -29,7 +29,7 @@
 * [Monitoring](#monitoring)
     * [<a href="snmp.md">SNMP</a>](#snmp)
     * [<a href="logging.md">SYSLOG</a>](#syslog)
-    * [<a href="rpm.md">RPM</a>](#rpm)
+    * [<a href="probes.md">Probes</a>](#probes)
 * [Hot Standby Router Protocol](#hsrp)
     * [<a href="hsrp.md">HSRP</a>](#hsrp)
 * [Access control](#access-control)
@@ -108,7 +108,7 @@
 
 #### [SYSLOG](logging.md)
 
-#### [RPM](rpm.md)
+#### [Probes](probes.md)
 
 # Hot Standby Router Protocol
 

--- a/Configuration datasets/interfaces/subinterface_common.md
+++ b/Configuration datasets/interfaces/subinterface_common.md
@@ -37,7 +37,8 @@ frinx-openconfig-interfaces:interfaces/interface/{{eth_url_intf-id}}/subinterfac
             {
                 "index": {{sub_ifc_index}},
                 "config": {
-                    "index": {{sub_ifc_index}}
+                    "index": {{sub_ifc_index}},
+                    "juniper-if-ext:rpm-type": {{rpm_type}}
                 },
                 "frinx-openconfig-if-ip:ipv4": {
                     "addresses": {


### PR DESCRIPTION
We can set rpm-type even if submodule-index is not only 0 but other
value in Junos18.
Fix the link to rpm in README.md to the link to probes.